### PR TITLE
feat: add LoadingButton component and integrate it into Transition

### DIFF
--- a/src/components/ui/LoadingButton/LoadingButton.tsx
+++ b/src/components/ui/LoadingButton/LoadingButton.tsx
@@ -1,0 +1,46 @@
+import { Button, ButtonProps, CircularProgress } from '@mui/material'
+import { PropsWithChildren, useCallback, useState } from 'react'
+
+type Props = {
+  isLoading: boolean
+} & ButtonProps
+
+export function LoadingButton({
+  children,
+  isLoading,
+  ...buttonProps
+}: PropsWithChildren<Props>) {
+  const [dimensions, setDimensions] = useState({
+    width: 0,
+    height: 0,
+  })
+
+  const ref = useCallback(
+    (el: HTMLButtonElement | null) => {
+      if (el && !dimensions.width && !dimensions.height) {
+        setDimensions({
+          width: el.offsetWidth,
+          height: el.offsetHeight,
+        })
+      }
+    },
+    [dimensions.width, dimensions.height],
+  )
+
+  return isLoading ? (
+    <Button
+      variant="contained"
+      disabled
+      sx={{
+        width: dimensions.width,
+        height: dimensions.height,
+      }}
+    >
+      <CircularProgress size={24} />
+    </Button>
+  ) : (
+    <Button variant="contained" {...buttonProps} ref={ref}>
+      {children}
+    </Button>
+  )
+}

--- a/src/pages/React19/components/Transition/Transition.tsx
+++ b/src/pages/React19/components/Transition/Transition.tsx
@@ -1,7 +1,8 @@
-import { useState, useTransition, useCallback } from 'react'
-import { Button, Typography } from '@mui/material'
+import { Typography } from '@mui/material'
 import { Box } from '@mui/system'
+import { useCallback, useState, useTransition } from 'react'
 import { EquipmentTitle } from '~/components/feature/EquipmentTitle/EquipmentTitle'
+import { LoadingButton } from '~/components/ui/LoadingButton/LoadingButton'
 
 export function Transition() {
   const [count, setCount] = useState(0)
@@ -32,14 +33,15 @@ export function Transition() {
         >
           useTransition に非同期関数（a.k.a Actions）を渡せるようになった
         </Typography>
-        <Button variant="contained" onClick={handleClick}>
+
+        <LoadingButton
+          isLoading={isPending}
+          variant="contained"
+          onClick={handleClick}
+        >
           Increment
-        </Button>
-        {isPending ? (
-          <Typography>loading...</Typography>
-        ) : (
-          <Typography>count = {count}</Typography>
-        )}
+        </LoadingButton>
+        <Typography>{isPending ? 'loading...' : `count = ${count}`}</Typography>
       </Box>
     </Box>
   )


### PR DESCRIPTION
- Introduced a new LoadingButton component that displays a loading spinner when in a loading state.
- Updated the Transition component to use LoadingButton instead of a standard Button, enhancing user experience during asynchronous operations.